### PR TITLE
feat: send bug report warning comment

### DIFF
--- a/src/lib/server/trigger-dev/jobs/check-run.ts
+++ b/src/lib/server/trigger-dev/jobs/check-run.ts
@@ -410,32 +410,7 @@ async function runBugReportJob<T extends IOWithIntegrations<{ github: Autoinvoic
   });
 
   if (!bugReportComment) {
-    await io.runTask('add-bug-report-warning', async () => {
-      if (previousBugReportWarning) {
-        return await reinsertComment(
-          orgDetails.id,
-          payload.organization,
-          payload.repo,
-          submissionHeaderComment('Bug Report', payload.prNumber.toString()),
-          payload.prNumber,
-          io
-        );
-      } else {
-        const comment = await createComment(
-          orgDetails.id,
-          payload.organization,
-          payload.repo,
-          bodyWithHeader(
-            'Bug Report',
-            `@${payload.senderLogin} please use git blame and specify the link to the commit link that has introduced this bug. Send the following message in this PR: \`${bugReportPrefix} [link] && bug author @name\``,
-            payload.prNumber.toString()
-          ),
-          payload.prNumber,
-          io
-        );
-        return comment;
-      }
-    });
+    await addBugReportWarning(previousBugReportWarning, orgDetails, payload, io);
   } else {
     if (previousBugReportWarning) {
       await io.runTask('delete-bug-report-warning', async () => {
@@ -477,6 +452,39 @@ async function runBugReportJob<T extends IOWithIntegrations<{ github: Autoinvoic
   // } else {
   //   // add message
   // }
+}
+
+async function addBugReportWarning(
+  previousBugReportWarning: IssueComment | undefined,
+  orgDetails: { id: number },
+  payload: EventSchema,
+  io: any
+) {
+  return await io.runTask('add-bug-report-warning', async () => {
+    if (previousBugReportWarning) {
+      return await reinsertComment(
+        orgDetails.id,
+        payload.organization,
+        payload.repo,
+        submissionHeaderComment('Bug Report', payload.prNumber.toString()),
+        payload.prNumber,
+        io
+      );
+    } else {
+      return await createComment(
+        orgDetails.id,
+        payload.organization,
+        payload.repo,
+        bodyWithHeader(
+          'Bug Report',
+          `@${payload.senderLogin} please use git blame and specify the link to the commit link that has introduced this bug. Send the following message in this PR: \`${bugReportPrefix} [link] && bug author @name\``,
+          payload.prNumber.toString()
+        ),
+        payload.prNumber,
+        io
+      );
+    }
+  });
 }
 
 async function getPrInfoByCheckRunNodeId<T extends Octokit>(

--- a/src/lib/server/trigger-dev/jobs/check-run.ts
+++ b/src/lib/server/trigger-dev/jobs/check-run.ts
@@ -259,7 +259,7 @@ async function runSubmissionJob<T extends IOWithIntegrations<{ github: Autoinvoi
   // if success -> check comment -> create if not exits -> update the list
 
   const previous = await io.runTask('get previous comment', async () => {
-    const previous = await getPreviousComment(
+    return await getPreviousComment(
       orgDetails.id,
       payload.organization,
       payload.repo,
@@ -269,7 +269,6 @@ async function runSubmissionJob<T extends IOWithIntegrations<{ github: Autoinvoi
       'bot',
       io
     );
-    return previous;
   });
   let current: any = null;
 

--- a/src/lib/server/trigger-dev/jobs/check-run.ts
+++ b/src/lib/server/trigger-dev/jobs/check-run.ts
@@ -382,7 +382,7 @@ async function runBugReportJob<T extends IOWithIntegrations<{ github: Autoinvoic
   );
 
   const bugReportComment = await io.runTask('get-report-comment', async () => {
-    const comment = await getPreviousComment(
+    return await getPreviousComment(
       orgDetails.id,
       payload.organization,
       payload.repo,
@@ -392,11 +392,10 @@ async function runBugReportJob<T extends IOWithIntegrations<{ github: Autoinvoic
       'others',
       io
     );
-    return comment;
   });
 
   const previousBugReportWarning = await io.runTask('get-previous-bug-report-warning', async () => {
-    const comment = await getPreviousComment(
+    return await getPreviousComment(
       orgDetails.id,
       payload.organization,
       payload.repo,
@@ -406,7 +405,6 @@ async function runBugReportJob<T extends IOWithIntegrations<{ github: Autoinvoic
       'bot',
       io
     );
-    return comment;
   });
 
   if (!bugReportComment) {

--- a/src/lib/server/trigger-dev/jobs/issues-comment.ts
+++ b/src/lib/server/trigger-dev/jobs/issues-comment.ts
@@ -7,7 +7,8 @@ import {
   submissionHeaderComment,
   getPullRequestByIssue,
   excludedAccounts,
-  reinsertComment
+  reinsertComment,
+  runPrFixCheckRun
 } from '../utils';
 
 export async function createJob<T extends IOWithIntegrations<{ github: Autoinvoicing }>>(
@@ -53,13 +54,15 @@ export async function createJob<T extends IOWithIntegrations<{ github: Autoinvoi
             orgDetails.id,
             org.name,
             repository.name,
-            submissionHeaderComment('Pull Request', pr.id),
+            submissionHeaderComment('Pull Request', pr.id.toString()),
             issue.number,
             io
           );
         },
         { name: 'Reinsert sticky comment' }
       );
+
+      await runPrFixCheckRun({ ...payload, pull_request: pr }, io);
 
       break;
     }

--- a/src/lib/server/trigger-dev/jobs/issues-creation.ts
+++ b/src/lib/server/trigger-dev/jobs/issues-creation.ts
@@ -40,6 +40,7 @@ export async function createJob<T extends IOWithIntegrations<{ github: Autoinvoi
           submissionHeaderComment('Issue', payload.issue.id.toString()),
           issue.number,
           'issue',
+          'bot',
           io
         );
 

--- a/src/lib/server/trigger-dev/utils.ts
+++ b/src/lib/server/trigger-dev/utils.ts
@@ -257,7 +257,6 @@ async function runPrFixCheckRun<
   }
 
   if (/^fix:/.test(title)) {
-    console.log('IN FIX PR CHECKER');
     // return io.logger.log('identified pull request');
 
     let pull_request: SimplePullRequest | PullRequest;

--- a/src/lib/server/trigger-dev/utils.ts
+++ b/src/lib/server/trigger-dev/utils.ts
@@ -256,8 +256,12 @@ async function runPrFixCheckRun<
     title = payload.issue.title;
   }
 
+  // TODO: remove this when the feature is ready
+  const dummy = true;
   if (/^fix:/.test(title)) {
-    // return io.logger.log('identified pull request');
+    if (dummy) {
+      return io.logger.log('identified pull request');
+    }
 
     let pull_request: SimplePullRequest | PullRequest;
     if ('pull_request' in payload) {


### PR DESCRIPTION
Resolves:
- #316 

Tasks:
- [x] Add logic for adding sticky warning comment (`@author please use git blame and specify...`)
- [x] Delete warning comment if user sends the submission already
- [x] Run pr fix check on `issue_comment` event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced comment management for GitHub pull requests, including the ability to create, update, and delete comments based on submission status.
	- Introduced a new prefix for bug report comments to streamline identification.
	- Added support for handling comments on both pull requests and issues.

- **Bug Fixes**
	- Improved retrieval of previous comments to ensure accurate updates and deletions based on the comment author.

- **Documentation**
	- Updated function signatures to reflect new capabilities and parameters for better clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->