### PR TITLE
fix: stick comment to the bottom of PR

### DIFF
--- a/integrations/autoinvoicing/package.json
+++ b/integrations/autoinvoicing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holdex/autoinvoicing",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "The Autoinvoicing GitHub integration for Trigger.dev",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/integrations/autoinvoicing/src/orgs.ts
+++ b/integrations/autoinvoicing/src/orgs.ts
@@ -19,6 +19,10 @@ export class Orgs {
     return this.runTask(
       key,
       async (client, task) => {
+        const currentWebhook = await client.rest.orgs.getWebhook({
+          org: params.org,
+          hook_id: params.hookId
+        });
         const result = await client.rest.orgs.updateWebhook({
           org: params.org,
           hook_id: params.hookId,
@@ -27,7 +31,7 @@ export class Orgs {
             url: params.url,
             secret: params.secret
           },
-          add_events: params.addEvents
+          events: Array.from(new Set([...currentWebhook.data.events, ...(params.addEvents ?? [])]))
         });
         return result.data;
       },

--- a/src/lib/server/trigger-dev/utils.ts
+++ b/src/lib/server/trigger-dev/utils.ts
@@ -342,27 +342,22 @@ async function deleteComment(
   previousComment: any,
   io: any
 ): Promise<boolean> {
-  try {
-    if (previousComment.databaseId) {
-      return await io.runTask(
-        `delete-comment-${previousComment.databaseId ?? ''}`,
-        async () => {
-          const octokit = await githubApp.getInstallationOctokit(orgID);
-          await octokit.rest.issues.deleteComment({
-            owner: orgName,
-            repo: repositoryName,
-            comment_id: previousComment.databaseId
-          });
-          return true;
-        },
-        { name: 'Delete comment' }
-      );
-    } else {
-      return false;
-    }
-  } catch (error) {
-    await io.logger.error('delete comment', { error });
-    return (error as { location: string })?.location === 'after_complete_task';
+  if (previousComment.databaseId) {
+    return await io.runTask(
+      `delete-comment-${previousComment.databaseId ?? ''}`,
+      async () => {
+        const octokit = await githubApp.getInstallationOctokit(orgID);
+        await octokit.rest.issues.deleteComment({
+          owner: orgName,
+          repo: repositoryName,
+          comment_id: previousComment.databaseId
+        });
+        return true;
+      },
+      { name: 'Delete comment' }
+    );
+  } else {
+    return false;
   }
 }
 

--- a/src/lib/server/trigger-dev/utils.ts
+++ b/src/lib/server/trigger-dev/utils.ts
@@ -346,13 +346,18 @@ async function deleteComment(
     return await io.runTask(
       `delete-comment-${previousComment.databaseId ?? ''}`,
       async () => {
-        const octokit = await githubApp.getInstallationOctokit(orgID);
-        await octokit.rest.issues.deleteComment({
-          owner: orgName,
-          repo: repositoryName,
-          comment_id: previousComment.databaseId
-        });
-        return true;
+        try {
+          const octokit = await githubApp.getInstallationOctokit(orgID);
+          await octokit.rest.issues.deleteComment({
+            owner: orgName,
+            repo: repositoryName,
+            comment_id: previousComment.databaseId
+          });
+          return true;
+        } catch (err) {
+          await io.logger.error('delete comment', { err });
+          return false;
+        }
       },
       { name: 'Delete comment' }
     );


### PR DESCRIPTION
Resolves #283 

Note: its necessary to update the autoinvoicing package.
After its published, Ill create another PR to update the package.json and pnpm-lock

## First Issue
From the production logs, looks like the issue_comment job is never run (except for truf-network)
![image](https://github.com/user-attachments/assets/94521069-a8dc-4eee-abcf-147085ab38c9)
This is due to issue in `updateWebhook` call where it passes a wrong argument, which makes the updated webhook events doesn't gets updated.
![image](https://github.com/user-attachments/assets/78ae4028-90f0-4196-8331-2b87b8ae767f)

### Solution
Fix the update webhook code, to use `events` instead of `add_events` which didn't exist as an argument.

## Second Issue
I'm not sure why, but if the task that deletes comment is wrapped inside a try-catch, it throws an error
![image](https://github.com/user-attachments/assets/6375b780-6f76-4229-a8cc-d47a6a55ac1b)
And the error location sometimes says `after_complete_task` or `before_complete_task`. In previous implementation, I check if its `before_complete_task`, I won't insert the sticky comment to prevent duplicate messages

### Solution
Once I move the try-catch inside the task, the error disappears
![image](https://github.com/user-attachments/assets/cc82acce-d40f-4e39-b03d-5e0c89cd98af)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling logic for comment deletion, ensuring more straightforward checks before executing deletion.
	- Enhanced readability of the deletion function by simplifying its structure.

- **New Features**
	- Updated the `updateWebhook` method to retain existing events while allowing the addition of new ones during webhook updates.
  
- **Chores**
	- Incremented version number for the `@holdex/autoinvoicing` package from `0.0.11` to `0.0.12`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->