### PR TITLE
feat: create github issue after run error

### DIFF
--- a/src/lib/server/trigger-dev/jobs/index.ts
+++ b/src/lib/server/trigger-dev/jobs/index.ts
@@ -12,6 +12,7 @@ import { createJob as createIssueJob } from './issues';
 import { createJob as createIssueCreationJob } from './issues-creation';
 import { createJob as createIssueCommentJob } from './issues-comment';
 import { createJob as createCheckRunJob, createEventJob as createCheckEventJob } from './check-run';
+import { getInstallationId, githubApp } from '../utils';
 
 config.integrationsList.forEach((org) => {
   client.defineJob({
@@ -143,11 +144,66 @@ if (!isDev) {
     }
   });
 
+  client.defineJob({
+    id: 'github-create-issue',
+    name: 'Create Github issue',
+    version: '0.0.1',
+    trigger: eventTrigger({
+      name: 'github-create-issue',
+      schema: zod.object({
+        content: zod.string(),
+        title: zod.string()
+      })
+    }),
+    run: async (payload, io) => {
+      const { content, title } = payload;
+
+      io.logger.info('Create Github issue', { content, title });
+
+      const targetIssueRepo = 'pr-time-tracker';
+      const targetIssueOwner = 'holdex';
+
+      const orgDetails = await io.runTask(
+        'get org installation',
+        async () => {
+          const { data } = await getInstallationId(targetIssueOwner);
+          return data;
+        },
+        { name: 'Get Organization installation' },
+        (err: any, _, _io) => {
+          _io.logger.error(err);
+        }
+      );
+
+      await io.runTask('Create Github issue', async () => {
+        const octokit = await githubApp.getInstallationOctokit(orgDetails.id);
+        const res = await octokit.rest.issues.create({
+          owner: targetIssueOwner,
+          repo: targetIssueRepo,
+          title,
+          body: content,
+          labels: ['bug']
+        });
+        return res.data;
+      });
+    }
+  });
+
   client.on('runFailed', (notification) => {
+    const content = `${notification.job.id} failed to run. More info on https://cloud.trigger.dev/orgs/${notification.organization.slug}/projects/${notification.project.slug}/jobs/${notification.job.id}/runs/${notification.id}/trigger`;
+
     client.sendEvent({
       name: 'discord-send-message',
       payload: {
-        content: `${notification.job.id} failed to run. More info on https://cloud.trigger.dev/orgs/${notification.organization.slug}/projects/${notification.project.slug}/jobs/${notification.job.id}/runs/${notification.id}/trigger`
+        content
+      }
+    });
+    client.sendEvent({
+      name: 'github-create-issue',
+      payload: {
+        notification,
+        title: `Job ${notification.job.id} failed to run`,
+        content
       }
     });
   });

--- a/src/lib/server/trigger-dev/jobs/index.ts
+++ b/src/lib/server/trigger-dev/jobs/index.ts
@@ -145,11 +145,11 @@ if (!isDev) {
   });
 
   client.defineJob({
-    id: 'github-create-issue',
-    name: 'Create Github issue',
+    id: 'github-create-bug-report-issue',
+    name: 'Create Github bug report issue',
     version: '0.0.1',
     trigger: eventTrigger({
-      name: 'github-create-issue',
+      name: 'github-create-bug-report-issue',
       schema: zod.object({
         content: zod.string(),
         title: zod.string()
@@ -157,8 +157,6 @@ if (!isDev) {
     }),
     run: async (payload, io) => {
       const { content, title } = payload;
-
-      io.logger.info('Create Github issue', { content, title });
 
       const targetIssueRepo = 'pr-time-tracker';
       const targetIssueOwner = 'holdex';
@@ -175,7 +173,7 @@ if (!isDev) {
         }
       );
 
-      await io.runTask('Create Github issue', async () => {
+      await io.runTask('create bug report issue', async () => {
         const octokit = await githubApp.getInstallationOctokit(orgDetails.id);
         const res = await octokit.rest.issues.create({
           owner: targetIssueOwner,
@@ -199,7 +197,7 @@ if (!isDev) {
       }
     });
     client.sendEvent({
-      name: 'github-create-issue',
+      name: 'github-create-bug-report-issue',
       payload: {
         notification,
         title: `Job ${notification.job.id} failed to run`,


### PR DESCRIPTION
resolves #267 

Example resulting issue: https://github.com/holdex/pr-time-tracker/issues/351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new job for creating GitHub bug report issues, triggered by the `github-create-bug-report-issue` event.
	- Enhanced error handling to send notifications to Discord and log job failures with detailed information, including links to job run details.

- **Bug Fixes**
	- Improved error handling during job execution to ensure better logging and notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->