### PR TITLE
chore: disable issue_comment and check_run

### DIFF
--- a/src/lib/server/trigger-dev/jobs/index.ts
+++ b/src/lib/server/trigger-dev/jobs/index.ts
@@ -39,6 +39,7 @@ config.integrationsList.forEach((org) => {
       event: events.onIssueComment,
       org: org.name
     }),
+    enabled: false,
     integrations: { github },
     run: async (payload, io, ctx) =>
       createIssueCommentJob<IOWithIntegrations<{ github: Autoinvoicing }>>(payload, io, ctx, org)
@@ -118,6 +119,7 @@ config.integrationsList.forEach((org) => {
       event: events.onCheckRun,
       org: org.name
     }),
+    enabled: false,
     concurrencyLimit: 1,
     integrations: { github },
     run: async (payload, io, ctx) =>

--- a/src/lib/server/trigger-dev/jobs/index.ts
+++ b/src/lib/server/trigger-dev/jobs/index.ts
@@ -24,6 +24,7 @@ config.integrationsList.forEach((org) => {
       event: events.onIssue,
       org: org.name
     }),
+    enabled: false,
     integrations: { github },
     run: async (payload, io, ctx) =>
       createIssueCreationJob<IOWithIntegrations<{ github: Autoinvoicing }>>(payload, io, ctx, org)
@@ -52,6 +53,7 @@ config.integrationsList.forEach((org) => {
       event: events.onIssueLabel,
       org: org.name
     }),
+    enabled: false,
     integrations: { github },
     run: async (payload, io, ctx) =>
       createIssueJob<IOWithIntegrations<{ github: Autoinvoicing }>>(payload, io, ctx, org)


### PR DESCRIPTION
resolves https://github.com/holdex/pr-time-tracker-webhooks/issues/448

I don't disable the custom-event yet, because its still used in the pull_requests events
once its merged, Ill check that the submission warning is not showing, and the reinsert warning doesn't work, and Ill enable the github app events for check_run and issue_comment 