### PR TITLE
chore: disable pull_requests and pull_request_review event

### DIFF
--- a/src/lib/server/trigger-dev/jobs/index.ts
+++ b/src/lib/server/trigger-dev/jobs/index.ts
@@ -69,6 +69,7 @@ config.integrationsList.forEach((org) => {
       event: events.onPullRequest,
       org: org.name
     }),
+    enabled: false,
     integrations: { github },
     run: async (payload, io, ctx) =>
       createPrJob<IOWithIntegrations<{ github: Autoinvoicing }>>(payload, io, ctx)
@@ -83,6 +84,7 @@ config.integrationsList.forEach((org) => {
       event: events.onPullRequestReview,
       org: org.name
     }),
+    enabled: false,
     integrations: { github },
     run: async (payload, io, ctx) =>
       createPrReviewJob<IOWithIntegrations<{ github: Autoinvoicing }>>(payload, io, ctx)
@@ -105,6 +107,7 @@ config.integrationsList.forEach((org) => {
         senderLogin: zod.string()
       })
     }),
+    enabled: false,
     concurrencyLimit: 1,
     integrations: { github },
     run: async (payload, io, ctx) =>
@@ -138,6 +141,7 @@ if (!isDev) {
         content: zod.string()
       })
     }),
+    enabled: false,
     run: async (payload, io) => {
       const { content } = payload;
 
@@ -152,6 +156,7 @@ if (!isDev) {
     id: 'github-create-bug-report-issue',
     name: 'Create Github bug report issue',
     version: '0.0.1',
+    enabled: false,
     trigger: eventTrigger({
       name: 'github-create-bug-report-issue',
       schema: zod.object({

--- a/src/lib/server/trigger-dev/jobs/index.ts
+++ b/src/lib/server/trigger-dev/jobs/index.ts
@@ -107,7 +107,6 @@ config.integrationsList.forEach((org) => {
         senderLogin: zod.string()
       })
     }),
-    enabled: false,
     concurrencyLimit: 1,
     integrations: { github },
     run: async (payload, io, ctx) =>
@@ -141,7 +140,6 @@ if (!isDev) {
         content: zod.string()
       })
     }),
-    enabled: false,
     run: async (payload, io) => {
       const { content } = payload;
 
@@ -156,7 +154,6 @@ if (!isDev) {
     id: 'github-create-bug-report-issue',
     name: 'Create Github bug report issue',
     version: '0.0.1',
-    enabled: false,
     trigger: eventTrigger({
       name: 'github-create-bug-report-issue',
       schema: zod.object({

--- a/src/lib/server/trigger-dev/jobs/index.ts
+++ b/src/lib/server/trigger-dev/jobs/index.ts
@@ -39,6 +39,7 @@ config.integrationsList.forEach((org) => {
       event: events.onIssueComment,
       org: org.name
     }),
+    enabled: false,
     integrations: { github },
     run: async (payload, io, ctx) =>
       createIssueCommentJob<IOWithIntegrations<{ github: Autoinvoicing }>>(payload, io, ctx, org)
@@ -118,6 +119,7 @@ config.integrationsList.forEach((org) => {
       event: events.onCheckRun,
       org: org.name
     }),
+    enabled: false,
     concurrencyLimit: 1,
     integrations: { github },
     run: async (payload, io, ctx) =>

--- a/src/lib/server/trigger-dev/jobs/index.ts
+++ b/src/lib/server/trigger-dev/jobs/index.ts
@@ -24,6 +24,7 @@ config.integrationsList.forEach((org) => {
       event: events.onIssue,
       org: org.name
     }),
+    enabled: false,
     integrations: { github },
     run: async (payload, io, ctx) =>
       createIssueCreationJob<IOWithIntegrations<{ github: Autoinvoicing }>>(payload, io, ctx, org)
@@ -52,6 +53,7 @@ config.integrationsList.forEach((org) => {
       event: events.onIssueLabel,
       org: org.name
     }),
+    enabled: false,
     integrations: { github },
     run: async (payload, io, ctx) =>
       createIssueJob<IOWithIntegrations<{ github: Autoinvoicing }>>(payload, io, ctx, org)


### PR DESCRIPTION
resolves https://github.com/holdex/pr-time-tracker-webhooks/issues/449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Update**
	- Disabled additional background jobs by default, including pull request streaming and review streaming.
	- Jobs remain configured but will not automatically run until explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->