### PR TITLE
fix: submission message not deleted after submit time

### DIFF
--- a/src/routes/api/submissions/+server.ts
+++ b/src/routes/api/submissions/+server.ts
@@ -41,6 +41,8 @@ export const POST: RequestHandler = async ({ url, request, cookies }) => {
 
     // get pr item
     const pr = await items.getOne({ id: body?.item_id });
+    const submission = await submissions.create(body!);
+
     if (pr) {
       // store these events in gcloud
       const event = {
@@ -61,7 +63,6 @@ export const POST: RequestHandler = async ({ url, request, cookies }) => {
         `${body?.item_id}_${contributor.login!}_${event.created_at}_${event.action}`
       );
 
-      // get last commit
       await triggerRequestCheckRun({
         org: pr.org,
         repoName: pr.repo,
@@ -72,7 +73,7 @@ export const POST: RequestHandler = async ({ url, request, cookies }) => {
     }
 
     return json({
-      data: await submissions.create(body!)
+      data: submission
     });
   } catch (e) {
     return jsonError(e, '/api/submissions', 'POST');


### PR DESCRIPTION
resolves https://github.com/holdex/pr-time-tracker-webhooks/issues/493

## Issue
in the case of the issue tagged, I saw that the custom event (to remove the message after submit) is triggered correctly. But in the steps there, it checks if the submission is already in mongo.
This is the issue, the submission result is not there. So I assume the mongo record insertion somehow takes a pretty long time, which makes the trigger dev runs first before the submission is inserted
https://cloud.trigger.dev/orgs/holdex-9fa1/projects/v3/pr-time-tracker-3GFO/runs/run_8ext7a9ba22cbaaah1x78?span=ea6b5d2646d832a8&tab=overview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the submission workflow to create and return a submission record in a single step.
  - Improved data integrity and efficiency during submission handling, resulting in a more consistent and reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->